### PR TITLE
Add retry logic to get desired location accuracy

### DIFF
--- a/app/constants/location.js
+++ b/app/constants/location.js
@@ -1,0 +1,27 @@
+/**
+ * The max amount of attempts to get desired accuracy.
+ * @type {number}
+ */
+export const MAX_ACCURACY_RETRY = 2;
+
+/**
+ * The desired accuracy (in meters) quality which serves as a threshold.
+ *
+ * @type {number}
+ */
+export const DESIRED_ACCURACY_QUALITY = 30;
+
+/**
+ * The desired location interval, and the minimum acceptable interval.
+ * Time (in milliseconds) between location information polls.
+ * E.g. 60000*5 = 5 minutes
+ * @type {number}
+ */
+export const LOCATION_INTERVAL = 60000 * 5;
+
+/**
+ * Maximum time that we will backfill for missing data
+ * Time (in milliseconds).  60000 * 60 * 8 = 24 hours
+ * @type {number}
+ */
+export const MAX_BACKFILL_TIME = 60000 * 60 * 24;

--- a/app/helpers/location.js
+++ b/app/helpers/location.js
@@ -1,0 +1,43 @@
+import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
+
+import {
+  DESIRED_ACCURACY_QUALITY,
+  MAX_ACCURACY_RETRY,
+} from '../constants/location';
+
+/**
+ * Retry to get location until desired accuracy level is met.
+ * NOTE: Location might be not accurate even the required accuracy level is set high.
+ *
+ * @param location
+ * @param callback
+ * @param attempt
+ */
+export function retryTillDesiredAccuracyMet(location, callback, attempt = 0) {
+  const metAccuracyThreshold =
+    false && location.accuracy < DESIRED_ACCURACY_QUALITY;
+  const isAbleToRetry = attempt < MAX_ACCURACY_RETRY;
+  if (!metAccuracyThreshold && isAbleToRetry) {
+    BackgroundGeolocation.getCurrentLocation(
+      newLocation => {
+        // in case of success pick which one of the locations has better accuracy
+        const bestAccuracyLocation =
+          newLocation.accuracy < location.accuracy ? newLocation : location;
+        retryTillDesiredAccuracyMet(
+          bestAccuracyLocation,
+          callback,
+          attempt + 1,
+        );
+      },
+      () => {
+        // in case of failure just try one more time
+        retryTillDesiredAccuracyMet(location, callback, attempt + 1);
+      },
+      {
+        enableHighAccuracy: true,
+      },
+    );
+  } else {
+    callback(location);
+  }
+}


### PR DESCRIPTION
<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

As suggested, retry logic is added in case GPS location returns a low accuracy location. There might be up to 2 retries until the required accuracy of 30 (I guess meters is met). If non of the returned locations has met the threshold the most accurate location is being stored.

If this doesn't improve things much we can try forking [mauron85
/
background-geolocation-android](https://github.com/mauron85/background-geolocation-android/) and updating `ACCURACY_FINE` to `ACCURACY_HIGH` on [this line](https://github.com/mauron85/background-geolocation-android/blob/58464febf6901f1e489817e4425418d48443929b/src/main/java/com/marianhello/bgloc/LocationManager.java#L95).

Also, we can try asking paid geolocation lib providers if they can provide a license for a non-profit open source project :) Lib candidates:
- https://github.com/transistorsoft/react-native-background-geolocation
- https://radar.io/content/alternatives/react-native-background-geolocation-vs-radar

#### Linked issues:

https://pathcheck.atlassian.net/browse/SAF-93https://pathcheck.atlassian.net/browse/SAF-93

#### Screenshots:


#### How to test:

I need help testing this on a real device as I don't have Android phone. Emulator always returns a good accuracy location.

Android:
1. Install an application on a real device
2. Track the location
3. Stored location might potentially have a better quality
