### PR TITLE
Fix pilse animation on android devices with “notch”

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -506,7 +506,9 @@ const styles = StyleSheet.create({
     top: '-13%',
     left: 0,
     right: 0,
+    flex: 1,
     alignItems: 'center',
+    justifyContent: 'center',
   },
   mainTextAbove: {
     textAlign: 'center',


### PR DESCRIPTION
Fixed pulse animation for Pixel 3XL on LocationTracking screen.
**Before:**
![Screenshot from 2020-05-06 13-32-03](https://user-images.githubusercontent.com/24640349/81167549-0f266280-8f9e-11ea-8a20-dd6328020a48.png)
**After:**
![Screenshot from 2020-05-06 12-20-42](https://user-images.githubusercontent.com/24640349/81167541-0afa4500-8f9e-11ea-97f1-6bd2aabc37e9.png)
