### PR TITLE
[Fixed]: "Latest News " is displaying the blue processing screen , un…

### DIFF
--- a/app/views/News.js
+++ b/app/views/News.js
@@ -31,7 +31,7 @@ class NewsScreen extends Component {
       news_url: DEFAULT_NEWS_SITE_URL,
     };
     this.state = {
-      visible: true,
+      visible: false,
       default_news: default_news,
       newsUrls: [],
       current_page: 0,
@@ -47,7 +47,7 @@ class NewsScreen extends Component {
     return true;
   };
 
-  hideSpinner() {
+  hideSpinner() { 
     this.setState({
       visible: false,
     });
@@ -70,11 +70,12 @@ class NewsScreen extends Component {
             borderBottomRightRadius: 12,
           }}
           cacheEnabled
-          onLoad={() =>
-            this.setState({
-              visible: false,
-            })
-          }
+          startInLoadingState={true} //Show loading indicator in webweb
+          // onLoad={() =>
+          //   this.setState({
+          //     visible: false,
+          //   })
+          // }
         />
       </View>
     );
@@ -85,7 +86,7 @@ class NewsScreen extends Component {
 
     GetStoreData(AUTHORITY_NEWS)
       .then(nameNewsString => {
-        // Bring in news from the various authorities.  This is
+3        // Bring in news from the various authorities.  This is
         // pulled down from the web when you subscribe to an Authority
         // on the Settings page.
         let arr = [];
@@ -135,7 +136,7 @@ class NewsScreen extends Component {
                 sliderWidth={width}
                 itemWidth={width * 0.85}
                 layout={'default'}
-                scrollEnabled
+                scrollEnabled={this.state.newsUrls.length == 1 ? false : true} // ScrollEnabled will be false if single url.
               />
 
               {this.state.visible && (

--- a/app/views/News.js
+++ b/app/views/News.js
@@ -70,12 +70,7 @@ class NewsScreen extends Component {
             borderBottomRightRadius: 12,
           }}
           cacheEnabled
-          startInLoadingState={true} //Show loading indicator in webweb
-          // onLoad={() =>
-          //   this.setState({
-          //     visible: false,
-          //   })
-          // }
+          startInLoadingState={true} //Show loading indicator on web view
         />
       </View>
     );
@@ -86,7 +81,7 @@ class NewsScreen extends Component {
 
     GetStoreData(AUTHORITY_NEWS)
       .then(nameNewsString => {
-3        // Bring in news from the various authorities.  This is
+        // Bring in news from the various authorities.  This is
         // pulled down from the web when you subscribe to an Authority
         // on the Settings page.
         let arr = [];
@@ -136,7 +131,7 @@ class NewsScreen extends Component {
                 sliderWidth={width}
                 itemWidth={width * 0.85}
                 layout={'default'}
-                scrollEnabled={this.state.newsUrls.length == 1 ? false : true} // ScrollEnabled will be false if single url.
+                scrollEnabled={this.state.newsUrls.length !== 1} // ScrollEnabled will be disable if single new url.
               />
 
               {this.state.visible && (

--- a/app/views/News.js
+++ b/app/views/News.js
@@ -47,7 +47,7 @@ class NewsScreen extends Component {
     return true;
   };
 
-  hideSpinner() { 
+  hideSpinner() {
     this.setState({
       visible: false,
     });
@@ -70,7 +70,7 @@ class NewsScreen extends Component {
             borderBottomRightRadius: 12,
           }}
           cacheEnabled
-          startInLoadingState={true} //Show loading indicator on web view
+          startInLoadingState
         />
       </View>
     );


### PR DESCRIPTION
…less User tapped on that - ios App v1.0.1.

1) In Carousel, Scroll will be disable when get single url.
2) Show loading indicator in Webview.

<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

<!-- Description of what the PR does.  YOUR PR WILL BE REJECTED IF YOU DO NOT HAVE A DESCRIPTION -->

#### Linked issues:

#730 

#### Screenshots:

![image](https://user-images.githubusercontent.com/21999369/81328963-666e2500-90bb-11ea-841f-4b6c1e768f91.png)

#### How to test:

- Open the App
- Open Hamburger menu
- select "Latest News "
- Blue screen will display , with a processing sign
- It will display this blue screen continuously unless user tap/swipe on the blue screen .
