### PR TITLE
Only render mayo clinic link when language is english

### DIFF
--- a/app/views/main/MayoButton.js
+++ b/app/views/main/MayoButton.js
@@ -9,23 +9,32 @@ import { styles } from './style';
 const MAYO_COVID_URL = 'https://www.mayoclinic.org/coronavirus-covid-19';
 
 export const MayoButton = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const onPress = () => Linking.openURL(MAYO_COVID_URL);
+
+  /**
+   * Currently, the component is only enabled in English. This will
+   * be updated once there are language-specific resources to link to.
+   */
+  const isEnabled = i18n.language === 'en';
+
   return (
-    <View>
-      <TouchableOpacity onPress={onPress} style={styles.mayoInfoRow}>
-        <View style={styles.mayoInfoContainer}>
-          <Typography style={styles.mainMayoHeader} onPress={onPress}>
-            {t('label.home_mayo_link_heading')}
-          </Typography>
-          <Typography style={styles.mainMayoSubtext} onPress={onPress}>
-            {t('label.home_mayo_link_label')}
-          </Typography>
-        </View>
-        <View style={styles.arrowContainer}>
-          <Image source={foreArrow} />
-        </View>
-      </TouchableOpacity>
-    </View>
+    isEnabled && (
+      <View>
+        <TouchableOpacity onPress={onPress} style={styles.mayoInfoRow}>
+          <View style={styles.mayoInfoContainer}>
+            <Typography style={styles.mainMayoHeader} onPress={onPress}>
+              {t('label.home_mayo_link_heading')}
+            </Typography>
+            <Typography style={styles.mainMayoSubtext} onPress={onPress}>
+              {t('label.home_mayo_link_label')}
+            </Typography>
+          </View>
+          <View style={styles.arrowContainer}>
+            <Image source={foreArrow} />
+          </View>
+        </TouchableOpacity>
+      </View>
+    )
   );
 };

--- a/app/views/main/__tests__/MayoButton.spec.js
+++ b/app/views/main/__tests__/MayoButton.spec.js
@@ -1,0 +1,27 @@
+import 'react-native';
+
+import { act, render } from '@testing-library/react-native';
+import React from 'react';
+
+import { setUserLocaleOverride } from '../../../locales/languages';
+import { MayoButton } from '../MayoButton';
+
+it('does not render when the language is not english', async () => {
+  await act(async () => {
+    await setUserLocaleOverride('es');
+  });
+
+  const { asJSON } = render(<MayoButton />);
+
+  expect(asJSON()).toMatchSnapshot();
+});
+
+it('renders when the language isenglish', async () => {
+  await act(async () => {
+    await setUserLocaleOverride('en');
+  });
+
+  const { asJSON } = render(<MayoButton />);
+
+  expect(asJSON()).toMatchSnapshot();
+});

--- a/app/views/main/__tests__/MayoButton.spec.js
+++ b/app/views/main/__tests__/MayoButton.spec.js
@@ -16,7 +16,7 @@ it('does not render when the language is not english', async () => {
   expect(asJSON()).toMatchSnapshot();
 });
 
-it('renders when the language isenglish', async () => {
+it('renders when the language is english', async () => {
   await act(async () => {
     await setUserLocaleOverride('en');
   });

--- a/app/views/main/__tests__/__snapshots__/MayoButton.spec.js.snap
+++ b/app/views/main/__tests__/__snapshots__/MayoButton.spec.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`does not render when the language is not english 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+/>
+`;
+
+exports[`renders when the language isenglish 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View>
+    <View
+      accessible={true}
+      focusable={true}
+      isTVSelectable={true}
+      style={
+        Object {
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "opacity": 1,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignContent": "flex-end",
+            "flexDirection": "column",
+            "justifyContent": "space-between",
+            "padding": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "#E5E4E6",
+              "fontFamily": "IBMPlexSans-Bold",
+              "fontSize": 18,
+              "fontWeight": "normal",
+              "lineHeight": 24,
+              "textAlign": "left",
+              "writingDirection": "ltr",
+            }
+          }
+          use="body1"
+        >
+          More COVID-19 information
+        </Text>
+        <Text
+          style={
+            Object {
+              "color": "#E5E4E6",
+              "fontFamily": "IBMPlexSans",
+              "fontSize": 18,
+              "fontWeight": "normal",
+              "lineHeight": 24,
+              "textAlign": "left",
+              "writingDirection": "ltr",
+            }
+          }
+          use="body1"
+        >
+          from the Mayo Clinic
+        </Text>
+      </View>
+      <View
+        style={
+          Object {
+            "alignSelf": "center",
+            "paddingLeft": 20,
+            "paddingRight": 20,
+          }
+        }
+      >
+        <Image
+          source={
+            Object {
+              "testUri": "../../../app/assets/images/foreArrow.png",
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/app/views/main/__tests__/__snapshots__/MayoButton.spec.js.snap
+++ b/app/views/main/__tests__/__snapshots__/MayoButton.spec.js.snap
@@ -12,7 +12,7 @@ exports[`does not render when the language is not english 1`] = `
 />
 `;
 
-exports[`renders when the language isenglish 1`] = `
+exports[`renders when the language is english 1`] = `
 <View
   collapsable={true}
   pointerEvents="box-none"


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

<!-- Required: read https://github.com/Path-Check/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request.  PR's raised not following those guidelines will require rework, so you might as well start off right -->

#### Description:

Only renders the `<MayoButton />` component when the user's language is set to `en`. This work is included in the `<Main />` component and therefore is currently under the `flag_better_location_status_checks` feature flag.

#### Linked issues:

https://pathcheck.atlassian.net/browse/SAF-48

#### Screenshots:

**English**
<img width="392" alt="Screen Shot 2020-05-08 at 3 05 39 PM" src="https://user-images.githubusercontent.com/20157849/81444948-aaa20980-913d-11ea-9637-5909f0932ec7.png">

**Not English**
<img width="390" alt="Screen Shot 2020-05-08 at 3 05 51 PM" src="https://user-images.githubusercontent.com/20157849/81444956-ad046380-913d-11ea-9e8d-913fa8d57347.png">

#### How to test:

- Confirm that the Mayo Button is visible when the language is not English
- Confirm that the Mayo Button is not visible when the language is not English
- Verify that all tests are passing: `jest --config=./jest/config.js app/views/main/__tests__/MayoButton.spec.js`
