### PR TITLE
removed redirect notices for EULA links

### DIFF
--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -27,12 +27,11 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
   const eulaPath = EULA_FILES[selectedLocale] || en;
 
   // Any links inside the EULA should launch a separate browser otherwise you can get stuck inside the app
-  shouldStartLoadWithRequestHandler = (webViewState) => {
+  const shouldStartLoadWithRequestHandler = webViewState => {
     if (webViewState.url != 'about:blank') {
       Linking.openURL(webViewState.url);
       return false;
-    }
-    else return true;
+    } else return true;
   };
 
   // Load the EULA from disk
@@ -63,7 +62,15 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
                   accessibilityLabel='Close'
                   onPress={() => setModalVisibility(false)}
                 />
-                {html && <WebView style={{ flex: 1,}} source={{ html }} onShouldStartLoadWithRequest={this.shouldStartLoadWithRequestHandler.bind(this)}/>}
+                {html && (
+                  <WebView
+                    style={{ flex: 1 }}
+                    source={{ html }}
+                    onShouldStartLoadWithRequest={
+                      shouldStartLoadWithRequestHandler
+                    }
+                  />
+                )}
               </View>
             </SafeAreaView>
           </Theme>

--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -17,6 +17,8 @@ import { Typography } from './Typography';
 
 const EULA_FILES = { en, ht };
 
+const DEFAULT_EULA_URL = 'about:blank';
+
 export const EulaModal = ({ selectedLocale, continueFunction }) => {
   const [modalVisible, setModalVisibility] = useState(false);
   const [boxChecked, toggleCheckbox] = useState(false);
@@ -28,10 +30,14 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
 
   // Any links inside the EULA should launch a separate browser otherwise you can get stuck inside the app
   const shouldStartLoadWithRequestHandler = webViewState => {
-    if (webViewState.url != 'about:blank') {
+    let shouldLoadRequest = true;
+    if (webViewState.url !== DEFAULT_EULA_URL) {
+      // If the webpage to load isn't the EULA, load it in a separate browser
       Linking.openURL(webViewState.url);
-      return false;
-    } else return true;
+      // Don't load the page if its being handled in a separate browser
+      shouldLoadRequest = false;
+    }
+    return shouldLoadRequest;
   };
 
   // Load the EULA from disk

--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Modal, StyleSheet, View } from 'react-native';
+import { Linking, Modal, StyleSheet, View } from 'react-native';
 import loadLocalResource from 'react-native-local-resource';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import WebView from 'react-native-webview';
@@ -25,6 +25,15 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
 
   // Pull the EULA in the correct language, with en as fallback
   const eulaPath = EULA_FILES[selectedLocale] || en;
+
+  // Any links inside the EULA should launch a separate browser otherwise you can get stuck inside the app
+  shouldStartLoadWithRequestHandler = (webViewState) => {
+    if (webViewState.url != 'about:blank') {
+      Linking.openURL(webViewState.url);
+      return false;
+    }
+    else return true;
+  };
 
   // Load the EULA from disk
   useEffect(() => {
@@ -54,7 +63,7 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
                   accessibilityLabel='Close'
                   onPress={() => setModalVisibility(false)}
                 />
-                {html && <WebView style={{ flex: 1 }} source={{ html }} />}
+                {html && <WebView style={{ flex: 1,}} source={{ html }} onShouldStartLoadWithRequest={this.shouldStartLoadWithRequestHandler.bind(this)}/>}
               </View>
             </SafeAreaView>
           </Theme>

--- a/app/locales/eula/en.html
+++ b/app/locales/eula/en.html
@@ -96,9 +96,7 @@
       <strong>“Safe Places Software</strong>” means open-source software,
       available at
       <span class="c8"
-        ><a
-          class="c11"
-          href="https://github.com/tripleblindmarket/safe-places"
+        ><a class="c11" href="https://github.com/tripleblindmarket/safe-places"
           >https://github.com/tripleblindmarket/safe-places</a
         >
         , that facilitates contact tracing and related tasks, and is designed

--- a/app/locales/eula/en.html
+++ b/app/locales/eula/en.html
@@ -98,7 +98,7 @@
       <span class="c8"
         ><a
           class="c11"
-          href="https://www.google.com/url?q=https://github.com/tripleblindmarket/safe-places&amp;sa=D&amp;ust=1587722145899000"
+          href="https://github.com/tripleblindmarket/safe-places"
           >https://github.com/tripleblindmarket/safe-places</a
         >
         , that facilitates contact tracing and related tasks, and is designed
@@ -139,7 +139,7 @@
       <span class="c8"
         ><a
           class="c11"
-          href="https://www.google.com/url?q=https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE&amp;sa=D&amp;ust=1587722145900000"
+          href="https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE"
           >https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a
         ></span
       >


### PR DESCRIPTION
#### Description:

Fixes issue where links within the EULA would trigger redirect notices. It also makes clicking links within the EULA launch in a separate web browser (without this you end up with github pages running inside the license screen of the app with no back functionality to return to the EULA).

#### Linked issues:

https://github.com/Path-Check/covid-safe-paths/issues/739

#### Screenshots:

No visual changes

#### How to test:

In the EULA screen, click any of the two active links on the page. They should launch in your phones default web browser and not give you a redirect notice
