### PR TITLE
Fix EULA modal close icon color

### DIFF
--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -58,7 +58,7 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
       />
       <Modal animationType='slide' transparent visible={modalVisible}>
         <View style={styles.container}>
-          <Theme use='violet'>
+          <Theme use='default'>
             <SafeAreaView style={{ flex: 1 }}>
               <View style={{ flex: 7, paddingHorizontal: 5 }}>
                 <IconButton


### PR DESCRIPTION
Fixes the white on white close icon

#### Linked issues:



#### Screenshots:

<img width="341" alt="Screen Shot 2020-05-10 at 12 00 11 PM" src="https://user-images.githubusercontent.com/702990/81512416-4dd95700-92d5-11ea-8065-6682f88ac31d.png">


#### How to test:

Check the EULA modal for a button on iOS and Android
