### PR TITLE
Remove sensitive logging in checkIntersect

### DIFF
--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -254,7 +254,7 @@ function binarySearchForTime(array, targetTime) {
  *        Ideally those should probably be broken up better, but for now leaving it alone.
  */
 export async function checkIntersect() {
-  cconsole.log(
+  console.log(
     `[intersect] tick entering on ${isPlatformiOS() ? 'iOS' : 'Android'}`,
   );
   const result = await asyncCheckIntersect();

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -253,19 +253,19 @@ function binarySearchForTime(array, targetTime) {
  *        from the authority (e.g. the news url) since we get that in the same call.
  *        Ideally those should probably be broken up better, but for now leaving it alone.
  */
-export function checkIntersect() {
+export async function checkIntersect() {
   console.log(
     'Intersect tick entering on',
     isPlatformiOS() ? 'iOS' : 'Android',
   );
 
-  asyncCheckIntersect().then(result => {
-    if (result === null) {
-      console.log('[intersect] skipped');
-    } else {
-      console.log('[intersect] completed: ', result);
-    }
-  });
+  const result = await asyncCheckIntersect();
+
+  if (result === null) {
+    console.log('[intersect] skipped');
+  } else {
+    console.log('[intersect] completed');
+  }
 }
 
 /**

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -254,18 +254,11 @@ function binarySearchForTime(array, targetTime) {
  *        Ideally those should probably be broken up better, but for now leaving it alone.
  */
 export async function checkIntersect() {
-  console.log(
-    'Intersect tick entering on',
-    isPlatformiOS() ? 'iOS' : 'Android',
+  cconsole.log(
+    `[intersect] tick entering on ${isPlatformiOS() ? 'iOS' : 'Android'}`,
   );
-
   const result = await asyncCheckIntersect();
-
-  if (result === null) {
-    console.log('[intersect] skipped');
-  } else {
-    console.log('[intersect] completed');
-  }
+  console.log(`[intersect] ${result ? 'completed' : 'skipped'}`);
 }
 
 /**


### PR DESCRIPTION
Remove sensitive info logging

#### Linked issues:

https://pathcheck.atlassian.net/browse/SAF-236

#### Screenshots:

NA

#### How to test:

Check the metro logs while viewing the main exposure screen

```
 LOG  Intersect tick entering on Android
 LOG  [intersect] completed
```
