### PR TITLE
Restore charcoal background on exposure page

### DIFF
--- a/app/views/main/ExposurePage.js
+++ b/app/views/main/ExposurePage.js
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Dimensions, ImageBackground, StatusBar, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 
-import backgroundImage from './../../assets/images/launchScreenBackground.png';
+import backgroundImage from '../../assets/images/backgroundAtRisk.png';
 import StateAtRisk from '../../assets/svgs/stateAtRisk';
 import { Button } from '../../components/Button';
 import { Typography } from '../../components/Typography';

--- a/app/views/main/__tests__/__snapshots__/ExposurePage.spec.js.snap
+++ b/app/views/main/__tests__/__snapshots__/ExposurePage.spec.js.snap
@@ -25,7 +25,7 @@ exports[`may be exposed matches snapshot 1`] = `
     <Image
       source={
         Object {
-          "testUri": "../../../app/assets/images/launchScreenBackground.png",
+          "testUri": "../../../app/assets/images/backgroundAtRisk.png",
         }
       }
       style={


### PR DESCRIPTION
It was lost in the refactor.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

Before:
<img width="316" alt="Screen Shot 2020-05-12 at 5 08 55 PM" src="https://user-images.githubusercontent.com/702990/81758097-be1ede80-9475-11ea-805b-d28b794cec73.png">

After:
<img width="320" alt="Screen Shot 2020-05-12 at 5 08 33 PM" src="https://user-images.githubusercontent.com/702990/81758111-c414bf80-9475-11ea-8549-0b85b1378c27.png">


#### How to test:

Use exposure debug mode to force a warning, then check the main screen.
