### PR TITLE
limit staging ios builds and expand android staging builds

### DIFF
--- a/.github/workflows/staging-android.yml
+++ b/.github/workflows/staging-android.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - develop
+      - master
+      - release-candidate
   pull_request:
     branches:
       - develop
+      - master
+      - release-candidate
 
 jobs:
   build_staging_android:

--- a/.github/workflows/staging-ios.yml
+++ b/.github/workflows/staging-ios.yml
@@ -1,12 +1,13 @@
 name: Staging iOS
 
+# Deliberately turned off the pull request logic here
+# because GitHub Actions explicitly turns off secrets for pull requests coming from a forked repo
 on:
   push:
     branches:
       - develop
-  pull_request:
-    branches:
-      - develop
+      - master
+      - release-candidate
 
 jobs:
   build_staging_ios:


### PR DESCRIPTION
#### Description:
Limit staging IOS builds to only run on push to protected branches. This job will fail to execute for any job triggered from a forked repository, because it is dependent on secrets for signing the test artifact, and Github Actions explicitly disables access to secrets in builds triggered by forks for security purposes