### PR TITLE
override remote permissions when we're not using them

### DIFF
--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -121,6 +121,7 @@ export default class LocationServices {
         // required on iOS only (see fetchCompletionHandler docs: https://github.com/react-native-community/react-native-push-notification-ios)
         notification.finish(PushNotificationIOS.FetchResult.NoData);
       },
+      // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
       requestPermissions: Platform.OS === 'ios',
     });
 

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -122,6 +122,7 @@ export default class LocationServices {
         notification.finish(PushNotificationIOS.FetchResult.NoData);
       },
       // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
+      // https://github.com/zo0r/react-native-push-notification#usage
       requestPermissions: Platform.OS === 'ios',
     });
 
@@ -224,8 +225,6 @@ export default class LocationServices {
     console.log('[INFO] BackgroundGeolocation auth status: ' + authorization);
 
     BackgroundGeolocation.start(); //triggers start on start event
-    // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
-    // https://github.com/zo0r/react-native-push-notification#usage
     isBackgroundGeolocationConfigured = true;
   }
 

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -223,6 +223,8 @@ export default class LocationServices {
     console.log('[INFO] BackgroundGeolocation auth status: ' + authorization);
 
     BackgroundGeolocation.start(); //triggers start on start event
+    // Setting the permissions to true causes a crash on Android, because that configuration requires Firebase
+    // https://github.com/zo0r/react-native-push-notification#usage
     isBackgroundGeolocationConfigured = true;
   }
 

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -1,6 +1,6 @@
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
 import PushNotificationIOS from '@react-native-community/push-notification-ios';
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 import PushNotification from 'react-native-push-notification';
 
 import { CROSSED_PATHS, PARTICIPATE } from '../constants/storage';
@@ -121,7 +121,7 @@ export default class LocationServices {
         // required on iOS only (see fetchCompletionHandler docs: https://github.com/react-native-community/react-native-push-notification-ios)
         notification.finish(PushNotificationIOS.FetchResult.NoData);
       },
-      requestPermissions: true,
+      requestPermissions: Platform.OS === 'ios',
     });
 
     const locationData = new LocationData();


### PR DESCRIPTION
# Description:
This is a merge into develop to match #825 

react-native-notifications requires firebase integration for Android if you're configuring the notifications with permissions set to true. This work-around comes from their docs, to avoid crashing Android when you're not using firebase.

# Linked issues:
https://pathcheck.atlassian.net/browse/SAF-234

# Screenshots:
![image](https://user-images.githubusercontent.com/2692908/81879423-c3088e80-9558-11ea-90b2-1ef9ef00fc49.png)


# How to test:
Run the app on Android.
Visit the Dashboard screen.
Disable & RE-Enable location in the Dashboard screen.
When I re-enabled location, I got a black screen with a Firebase error.
Expect that the app does not crash with the same red box error as shown above
Regression test on iOS
